### PR TITLE
Add eval to varnishd command line.

### DIFF
--- a/varnish/run
+++ b/varnish/run
@@ -2,7 +2,7 @@
 
 exec 2>&1
 
-exec /usr/sbin/varnishd -j unix -F \
+eval exec /usr/sbin/varnishd -j unix -F \
   -a :80 -T 127.0.0.1:6082 -S /etc/varnish/secret \
   $VARNISH_OPTIONS
   2>&1


### PR DESCRIPTION
This allows $VARNISH_OPTIONS to contain multiple arguments with internally quoted spaces, which we need for correct interpretation of the `-p cc_command=...` option.

@arora-richa 