### PR TITLE
Drop adm group as it is no longer needed.

### DIFF
--- a/varnishncsa/run
+++ b/varnishncsa/run
@@ -4,6 +4,6 @@ sv start varnish || exit 1
 
 exec 2>&1
 
-exec chpst -u varnish:varnish:adm \
+exec chpst -u varnish:varnish \
   /usr/bin/varnishncsa \
   -F "$VARNISHNCSA_LOGFORMAT"


### PR DESCRIPTION
@arora-richa 

I forgot to include this in the last PR, but the adm group was only necessary when doing file based logging.